### PR TITLE
Fix function inspection

### DIFF
--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -89,7 +89,9 @@ exports.start = (rinoreOptions) => {
         // show argument on preview
         Function.prototype[util_1.inspect.custom] = function () {
             const argsMatch = this.toString().match(/^function\s*[^(]*\(\s*([^)]*)\)/m)
-                || this.toString().match(/^[^(]*\(\s*([^)]*)\)/m);
+                || this.toString().match(/^[^(]*\(\s*([^)]*)\)/m)
+                || this.constructor.toString().match(/^function\s*[^(]*\(\s*([^)]*)\)/m)
+                || this.constructor.toString().match(/^[^(]*\(\s*([^)]*)\)/m);
             return `[Function: ${this.name}(${argsMatch[1]})]`;
         };
     }

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -86,8 +86,12 @@ export const start = (rinoreOptions: RinoreOptions): repl.REPLServer => {
   if (getMajorNodeVersion() >= 12) {
     // show argument on preview
     (Function.prototype as any)[inspect.custom] = function () {
-      const argsMatch = this.toString().match(/^function\s*[^(]*\(\s*([^)]*)\)/m)
-        || this.toString().match(/^[^(]*\(\s*([^)]*)\)/m);
+      const argsMatch =
+        this.toString().match(/^function\s*[^(]*\(\s*([^)]*)\)/m)
+        || this.toString().match(/^[^(]*\(\s*([^)]*)\)/m)
+        || this.constructor.toString().match(/^function\s*[^(]*\(\s*([^)]*)\)/m)
+        || this.constructor.toString().match(/^[^(]*\(\s*([^)]*)\)/m);
+
       return `[Function: ${this.name}(${argsMatch[1]})]`;
     };
   } else {


### PR DESCRIPTION
`this.toString()`가
`lodash`는 `''`입니다.
`ShopSync`는 `'class ShopSync extends model.BaseModel {\n}'`입니다.
`argsMatch`가 `null`이어서 `argsMatch[1]` 참조가 오류가 나고 있습니다.


이 수정사항을 반영할 경우 lodash나 ShopSync의 inspection은
`[Function: lodash()]`와 `[Function: ShopSync()]` 로 나옵니다.

lodash의 경우 inspection처럼 argument 없이 바로 호출해도 되지만 argument를 넘길 수도 있는데 그걸 못 봐서 조금 아쉽습니다.
ShopSync의 경우 constructor를 new로만 호출해야 하는데 바로 호출할 수 있을 것처럼 나와서 아쉽습니다. 그러나 `ShopSync()`까지 치면 `TypeError: Class constructor ShopSync cannot be invoked without 'new'`가 나오긴 합니다.